### PR TITLE
Better Link Extraction

### DIFF
--- a/Sources/LemmyMarkdownUI/Node/BlockNode.swift
+++ b/Sources/LemmyMarkdownUI/Node/BlockNode.swift
@@ -38,13 +38,24 @@ public enum BlockNode: Hashable, Node {
         }
     }
     
-    var searchChildrenForLinks: Bool {
+    internal var searchChildrenForLinks: Bool {
         switch self {
         case .spoiler:
             false
         default:
             true
         }
+    }
+    
+    public var links: [LinkData] {
+        if case .spoiler = self {
+            return children.links.map {
+                var new = $0
+                new.insideSpoiler = true
+                return new
+            }
+        }
+        return children.links
     }
 }
 

--- a/Sources/LemmyMarkdownUI/Node/InlineNode.swift
+++ b/Sources/LemmyMarkdownUI/Node/InlineNode.swift
@@ -22,7 +22,7 @@ public enum InlineNode: Hashable, Node {
     
     internal var children: [any Node] { inlineChildren }
     
-    var inlineChildren: [InlineNode] {
+    internal var inlineChildren: [InlineNode] {
         switch self {
         case let .emphasis(children):
             return children
@@ -43,7 +43,7 @@ public enum InlineNode: Hashable, Node {
         }
     }
     
-    var string: String? {
+    internal var string: String? {
         switch self {
         case let .text(string):
             return string
@@ -58,7 +58,25 @@ public enum InlineNode: Hashable, Node {
         }
     }
     
-    var searchChildrenForLinks: Bool { true }
+    public var links: [LinkData] {
+        var ret: [LinkData] = .init()
+        if case let InlineNode.link(destination: destination, children: children) = self {
+            if let url = URL(string: destination) {
+                ret.append(.init(title: children, url: url))
+            }
+        }
+        if self.searchChildrenForLinks {
+            ret += self.inlineChildren.links
+        }
+        return ret
+    }
+    
+    public var stringLiteral: String {
+        if let string { return string }
+        return inlineChildren.stringLiteral
+    }
+    
+    internal var searchChildrenForLinks: Bool { true }
 }
 
 internal extension InlineNode {

--- a/Sources/LemmyMarkdownUI/Node/LinkData.swift
+++ b/Sources/LemmyMarkdownUI/Node/LinkData.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Sjmarf on 26/05/2024.
+//
+
+import Foundation
+
+public struct LinkData {
+    public let title: [InlineNode]
+    public let url: URL
+    public var insideSpoiler: Bool = false
+}

--- a/Sources/LemmyMarkdownUI/Node/ListItemNode.swift
+++ b/Sources/LemmyMarkdownUI/Node/ListItemNode.swift
@@ -13,6 +13,7 @@ public struct ListItemNode: Hashable, Node {
     let blocks: [BlockNode]
     
     var children: [Node] { blocks }
+    public var links: [LinkData] { children.links }
 }
 
 internal extension ListItemNode {

--- a/Sources/LemmyMarkdownUI/Node/Node.swift
+++ b/Sources/LemmyMarkdownUI/Node/Node.swift
@@ -10,4 +10,5 @@ import Foundation
 internal protocol Node {
     var children: [any Node] { get }
     var searchChildrenForLinks: Bool { get }
+    var links: [LinkData] { get }
 }

--- a/Sources/LemmyMarkdownUI/Node/TableCellNode.swift
+++ b/Sources/LemmyMarkdownUI/Node/TableCellNode.swift
@@ -13,6 +13,7 @@ public struct TableCellNode: Hashable, Node {
     var children: [Node] { content }
     
     var searchChildrenForLinks: Bool { true }
+    public var links: [LinkData] { children.links }
 }
 
 internal extension TableCellNode {

--- a/Sources/LemmyMarkdownUI/Node/TableRowNode.swift
+++ b/Sources/LemmyMarkdownUI/Node/TableRowNode.swift
@@ -13,6 +13,7 @@ public struct TableRowNode: Hashable, Node {
     var children: [any Node] { cells }
     
     var searchChildrenForLinks: Bool { true }
+    public var links: [LinkData] { children.links }
 }
 
 internal extension TableRowNode {

--- a/Sources/LemmyMarkdownUI/Node/[BlockNode].swift
+++ b/Sources/LemmyMarkdownUI/Node/[BlockNode].swift
@@ -12,20 +12,7 @@ public extension [BlockNode] {
         self.init(UnsafeNode.parseMarkdown(markdown: markdown) ?? [])
     }
     
-    var links: [(title: [InlineNode], url: URL)] {
-        var ret: [(title: [InlineNode], url: URL)] = .init()
-        var stack: [any Node] = self
-        while !stack.isEmpty {
-            let node = stack.removeFirst()
-            if node.searchChildrenForLinks {
-                stack.append(contentsOf: node.children)
-            }
-            if case let InlineNode.link(destination: destination, children: children) = node {
-                if let url = URL(string: destination) {
-                    ret.append((title: children, url: url))
-                }
-            }
-        }
-        return ret
+    var links: [LinkData] {
+        self.reduce([], { $0 + $1.links })
     }
 }

--- a/Sources/LemmyMarkdownUI/Node/[InlineNode].swift
+++ b/Sources/LemmyMarkdownUI/Node/[InlineNode].swift
@@ -12,4 +12,12 @@ public extension [InlineNode] {
         let blocks: [BlockNode] = .init(markdown)
         self.init((blocks.first?.children as? [InlineNode]) ?? [])
     }
+    
+    var links: [LinkData] {
+        self.reduce([], { $0 + $1.links })
+    }
+    
+    var stringLiteral: String {
+        self.reduce("", { $0 + $1.stringLiteral })
+    }
 }

--- a/Sources/LemmyMarkdownUI/Node/[any Node].swift
+++ b/Sources/LemmyMarkdownUI/Node/[any Node].swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Sjmarf on 26/05/2024.
+//
+
+import Foundation
+
+internal extension [any Node] {
+    var links: [LinkData] {
+        self.reduce([], { $0 + $1.links })
+    }
+}


### PR DESCRIPTION
Access the `links` computed property on any node or array of nodes to get all of the links inside of it. The property returns `[LinkData]`, where `LinkData` is defined as:

```swift
public struct LinkData {
    public let title: [InlineNode]
    public let url: URL
    public var insideSpoiler: Bool = false
}
```

In Mlem, we can use this for tappable link rendering (see https://github.com/mlemgroup/mlem/issues/1072)

It takes 0.2 milliseconds to extract the links from the markdown tree currently contained in the `Profile` tab.