### PR TITLE
Markdown Truncation

### DIFF
--- a/Sources/LemmyMarkdownUI/MarkdownConfiguration.swift
+++ b/Sources/LemmyMarkdownUI/MarkdownConfiguration.swift
@@ -11,8 +11,45 @@ public struct MarkdownConfiguration {
     public let inlineImageLoader: (InlineImage) async -> Void
     @ViewBuilder public let imageBlockView: (_ image: InlineImage) -> AnyView
     
-    public init(inlineImageLoader: @escaping (InlineImage) async -> Void, imageBlockView: @escaping (_: InlineImage) -> AnyView) {
+    public let stubSpoilers: Bool
+    public let spoilerStubIcon: String
+    public let truncationTerminatorText: String?
+    
+    public let primaryColor: Color
+    public let secondaryColor: Color
+    public let spoilerHeaderBackgroundColor: Color
+    public let spoilerOutlineColor: Color
+    public let codeBackgroundColor: Color
+    public let quoteColor: Color
+    public let quoteBarColor: Color
+    
+    public init(
+        inlineImageLoader: @escaping (InlineImage) async -> Void,
+        imageBlockView: @escaping (_: InlineImage) -> AnyView,
+        stubSpoilers: Bool = false,
+        spoilerStubIcon: String = "eye.slash.fill",
+        truncationTerminatorText: String? = nil,
+        primaryColor: Color = .primary,
+        secondaryColor: Color = .secondary,
+        spoilerHeaderBackgroundColor: Color = .init(uiColor: .secondarySystemBackground),
+        spoilerOutlineColor: Color = Color(uiColor: .tertiaryLabel),
+        codeBackgroundColor: Color = .init(uiColor: .secondarySystemBackground),
+        quoteBarColor: Color = .init(uiColor: .tertiaryLabel),
+        quoteColor: Color = .primary
+    ) {
         self.inlineImageLoader = inlineImageLoader
         self.imageBlockView = imageBlockView
+        
+        self.stubSpoilers = stubSpoilers
+        self.spoilerStubIcon = spoilerStubIcon
+        self.truncationTerminatorText = truncationTerminatorText
+        
+        self.primaryColor = primaryColor
+        self.secondaryColor = secondaryColor
+        self.spoilerHeaderBackgroundColor = spoilerHeaderBackgroundColor
+        self.spoilerOutlineColor = spoilerOutlineColor
+        self.codeBackgroundColor = codeBackgroundColor
+        self.quoteBarColor = quoteBarColor
+        self.quoteColor = quoteColor
     }
 }

--- a/Sources/LemmyMarkdownUI/Node/InlineNode+applyAttributes.swift
+++ b/Sources/LemmyMarkdownUI/Node/InlineNode+applyAttributes.swift
@@ -9,7 +9,10 @@ import Foundation
 import SwiftUI
 
 internal extension InlineNode {
-    func applyAttributes(_ attributes: AttributeContainer) -> AttributeContainer {
+    func applyAttributes(
+        _ attributes: AttributeContainer,
+        configuration: MarkdownConfiguration
+    ) -> AttributeContainer {
         let font: UIFont = (attributes.uiKit.font) ?? .preferredFont(forTextStyle: .body)
         var attributes = attributes
         switch self {
@@ -29,7 +32,7 @@ internal extension InlineNode {
             )
         case .code:
             attributes.uiKit.font = UIFont.monospacedSystemFont(ofSize: font.pointSize, weight: .regular)
-            attributes.uiKit.backgroundColor = UIColor.secondarySystemBackground
+            attributes.backgroundColor = configuration.codeBackgroundColor
         case .superscript:
             let size = UIFont.bodyPointSize / 2
             attributes.uiKit.font = font.withSize(size)
@@ -41,6 +44,8 @@ internal extension InlineNode {
             attributes.strikethroughStyle = .single
         case let .link(destination: url, children: _):
             attributes.link = URL(string: url)
+        case .truncationTerminator:
+            attributes.foregroundColor = configuration.secondaryColor
         default:
             break
         }

--- a/Sources/LemmyMarkdownUI/Node/InlineNode.swift
+++ b/Sources/LemmyMarkdownUI/Node/InlineNode.swift
@@ -18,7 +18,11 @@ public enum InlineNode: Hashable, Node {
     case `subscript`(children: [InlineNode])
     case strikethrough(children: [InlineNode])
     case link(destination: String, children: [InlineNode])
-    case image(source: String, children: [InlineNode])
+    case image(source: String, children: [InlineNode], truncated: Bool = false)
+    
+    // Renders as an ellipsis. It can be inserted into the tree when the tree is truncated.
+    // This will never be created by the markdown parser.
+    case truncationTerminator
     
     internal var children: [any Node] { inlineChildren }
     
@@ -36,7 +40,7 @@ public enum InlineNode: Hashable, Node {
             return children
         case let .link(_, children):
             return children
-        case let .image(_, children):
+        case let .image(_, children, _):
             return children
         default:
             return []
@@ -53,6 +57,8 @@ public enum InlineNode: Hashable, Node {
             return " "
         case .lineBreak:
             return "\n"
+        case .truncationTerminator:
+            return "..."
         default:
             return nil
         }

--- a/Sources/LemmyMarkdownUI/Node/ListItemNode.swift
+++ b/Sources/LemmyMarkdownUI/Node/ListItemNode.swift
@@ -24,19 +24,19 @@ internal extension ListItemNode {
         self.init(blocks: unsafeNode.children.compactMap(BlockNode.init(unsafeNode:)))
     }
     
-    func truncate(remainingLines: inout Int, charactersPerLine: Int) -> ListItemNode {
-        return .init(blocks: blocks.truncate(remainingLines: &remainingLines, charactersPerLine: charactersPerLine))
+    func truncate(data: TruncationData) -> ListItemNode {
+        return .init(blocks: blocks.truncate(data: data))
     }
 }
 
 internal extension [ListItemNode] {
-    func truncate(remainingLines: inout Int, charactersPerLine: Int) -> [ListItemNode] {
+    func truncate(data: TruncationData) -> [ListItemNode] {
         var ret: [ListItemNode] = .init()
         for node in self {
-            if remainingLines <= 0 {
+            if data.linesRemaining <= 0 {
                 break
             }
-            ret.append(node.truncate(remainingLines: &remainingLines, charactersPerLine: charactersPerLine))
+            ret.append(node.truncate(data: data))
         }
         return ret
     }

--- a/Sources/LemmyMarkdownUI/Node/TruncationData.swift
+++ b/Sources/LemmyMarkdownUI/Node/TruncationData.swift
@@ -1,0 +1,19 @@
+//
+//  File.swift
+//  
+//
+//  Created by Sjmarf on 27/05/2024.
+//
+
+import Foundation
+
+internal class TruncationData {
+    var linesRemaining: Int
+    var charactersPerLine: Int
+    var hasInsertedTerminator: Bool = false
+    
+    init(linesRemaining: Int, charactersPerLine: Int) {
+        self.linesRemaining = linesRemaining
+        self.charactersPerLine = charactersPerLine
+    }
+}

--- a/Sources/LemmyMarkdownUI/Renderer/InlineImage.swift
+++ b/Sources/LemmyMarkdownUI/Renderer/InlineImage.swift
@@ -12,11 +12,12 @@ import SwiftUI
 public class InlineImage {
     public let url: URL
     public let fontSize: CGFloat
-    
     public var image: Image?
+    public let truncated: Bool
     
-    init(url: URL, fontSize: CGFloat) {
+    init(url: URL, fontSize: CGFloat, truncated: Bool = false) {
         self.url = url
         self.fontSize = fontSize
+        self.truncated = truncated
     }
 }

--- a/Sources/LemmyMarkdownUI/View/InlineMarkdown.swift
+++ b/Sources/LemmyMarkdownUI/View/InlineMarkdown.swift
@@ -27,7 +27,7 @@ public struct InlineMarkdown: View {
         _ inlines: [InlineNode],
         configuration: MarkdownConfiguration
     ) {
-        self.renderer = .init(inlines: inlines)
+        self.renderer = .init(inlines: inlines, configuration: configuration)
         self.configuration = configuration
     }
     

--- a/Sources/LemmyMarkdownUI/View/Markdown.swift
+++ b/Sources/LemmyMarkdownUI/View/Markdown.swift
@@ -9,7 +9,6 @@ import Foundation
 import SwiftUI
 
 public struct Markdown: View {
-    
     var blocks: [BlockNode]
     var configuration: MarkdownConfiguration
     
@@ -42,36 +41,56 @@ public struct Markdown: View {
                         heading(level: level, inlines: inlines)
                     case let .blockquote(blocks: blocks):
                         blockQuote(blocks: blocks)
-                    case let .table(columnAlignments: columnAlignments, rows: rows):
-                        TableView(columnAlignments: columnAlignments, rows: rows, configuration: configuration)
+                    case let .table(columnAlignments: columnAlignments, rows: rows, truncatedRows: truncatedRows):
+                        if truncatedRows == 0 {
+                            TableView(columnAlignments: columnAlignments, rows: rows, configuration: configuration)
+                        } else {
+                            TableView(columnAlignments: columnAlignments, rows: rows, configuration: configuration)
+                                .mask(fadeGradient)
+                        }
                     case let .spoiler(title: title, blocks: blocks):
                         SpoilerView(
                             title: title,
                             blocks: blocks,
                             configuration: configuration
                         )
-                    case let .codeBlock(fenceInfo: _, content: content):
-                        codeBlock(content: content)
+                    case let .codeBlock(fenceInfo: _, content: content, truncatedRows: truncatedRows):
+                        if truncatedRows == 0 {
+                            codeBlock(content: content)
+                        } else {
+                            codeBlock(content: content)
+                                .mask(fadeGradient)
+                        }
                     case .thematicBreak:
                         Rectangle()
                             .fill(Color(uiColor: .secondarySystemBackground))
                             .frame(height: 3)
                             .frame(maxWidth: .infinity)
-                    case let .bulletedList(isTight: _, items: items):
-                        bulletedList(items: items)
-                    case let .numberedList(isTight: _, start: start, items: items):
-                        numberedList(items: items, startIndex: start)
+                    case let .bulletedList(isTight: _, items: items, truncatedRows: truncatedRows):
+                        bulletedList(items: items, truncatedRows: truncatedRows)
+                    case let .numberedList(isTight: _, start: start, items: items, truncatedRows: truncatedRows):
+                        numberedList(items: items, startIndex: start, truncatedRows: truncatedRows)
+                    case .truncationTerminator:
+                        if let truncationTerminatorText = configuration.truncationTerminatorText {
+                            Text(truncationTerminatorText)
+                                .italic()
+                                .foregroundStyle(configuration.secondaryColor)
+                        }
                     }
                 }
                 .padding(.top, (index == 0) ? 0 : blockPadding(block, edge: .top))
                 .padding(.bottom, (index == blocks.count - 1) ? 0 : blockPadding(block, edge: .bottom))
             }
         }
+        .foregroundStyle(configuration.primaryColor)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
     
     func blockPadding(_ block: BlockNode, edge: VerticalEdge) -> CGFloat {
-        8
+        if block == .truncationTerminator, edge == .top {
+            return 0
+        }
+        return 8
     }
     
     @ViewBuilder
@@ -128,13 +147,13 @@ public struct Markdown: View {
                 .font(.body.monospaced())
                 .padding(10)
         }
-        .background(Color(uiColor: .secondarySystemBackground))
+        .background(configuration.codeBackgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: 8))
     }
     
     @ViewBuilder
-    func bulletedList(items: [ListItemNode]) -> some View {
-        VStack(spacing: 3) {
+    func bulletedList(items: [ListItemNode], truncatedRows: Int = 0) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
             ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                 HStack(alignment: .top, spacing: 8) {
                     Text(" ")
@@ -146,22 +165,36 @@ public struct Markdown: View {
                 }
                 .frame(maxWidth: .infinity)
             }
+            if truncatedRows != 0 {
+                Text("  + \(truncatedRows) more items...")
+                    .italic()
+                    .foregroundStyle(configuration.secondaryColor)
+            }
         }
         .frame(maxWidth: .infinity)
     }
     
     @ViewBuilder
-    func numberedList(items: [ListItemNode], startIndex: Int = 1) -> some View {
-        VStack(spacing: 3) {
+    func numberedList(items: [ListItemNode], startIndex: Int = 1, truncatedRows: Int = 0) -> some View {
+        VStack(alignment: .leading, spacing: 3) {
             ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                 HStack(alignment: .top, spacing: 7) {
                     Text("\(startIndex + index).")
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(configuration.secondaryColor)
                     Markdown(item.blocks, configuration: configuration)
                 }
                 .frame(maxWidth: .infinity)
             }
+            if truncatedRows != 0 {
+                Text("   + \(truncatedRows) more items...")
+                    .italic()
+                    .foregroundStyle(configuration.secondaryColor)
+            }
         }
         .frame(maxWidth: .infinity)
+    }
+    
+    var fadeGradient: some View {
+        LinearGradient(colors: [.black, .clear], startPoint: .top, endPoint: .bottom)
     }
 }

--- a/Sources/LemmyMarkdownUI/View/SpoilerView.swift
+++ b/Sources/LemmyMarkdownUI/View/SpoilerView.swift
@@ -30,6 +30,21 @@ internal struct SpoilerView: View {
     }
     
     var body: some View {
+        if configuration.stubSpoilers {
+            HStack {
+                Image(systemName: configuration.spoilerStubIcon)
+                InlineMarkdown(
+                    titleInlines,
+                    configuration: configuration
+                )
+            }
+            .foregroundStyle(configuration.secondaryColor)
+        } else {
+            content
+        }
+    }
+    
+    var content: some View {
         VStack(spacing: 0) {
             HStack(spacing: 12) {
                 Image(systemName: "chevron.right")
@@ -41,11 +56,11 @@ internal struct SpoilerView: View {
                 )
             }
             .fontWeight(.bold)
-            .foregroundStyle(.secondary)
+            .foregroundStyle(configuration.secondaryColor)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 10)
             .padding(.horizontal, 12)
-            .background(Color(uiColor: .secondarySystemBackground))
+            .background(configuration.spoilerHeaderBackgroundColor)
             .onTapGesture {
                 withAnimation(.easeInOut(duration: 0.2)) {
                     isCollapsed.toggle()
@@ -63,7 +78,7 @@ internal struct SpoilerView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
         .overlay(
             RoundedRectangle(cornerRadius: 12)
-                .stroke(Color(uiColor: .tertiaryLabel), lineWidth: 1)
+                .stroke(configuration.spoilerOutlineColor, lineWidth: 1)
         )
     }
 }

--- a/Sources/LemmyMarkdownUI/View/Table/TableView.swift
+++ b/Sources/LemmyMarkdownUI/View/Table/TableView.swift
@@ -14,6 +14,8 @@ public struct TableView: View {
     
     let borderWidth: CGFloat = 1
     
+    @State private var scrollViewContentSize: CGSize = .zero
+    
     public var body: some View {
         ScrollView(.horizontal) {
             Grid(horizontalSpacing: borderWidth, verticalSpacing: borderWidth) {
@@ -44,9 +46,22 @@ public struct TableView: View {
                     )
                 }
             }
+            .background(
+                GeometryReader { geo in
+                    geometryReaderBackground(geoSize: geo.size)
+                }
+            )
         }
+        .frame(maxWidth: scrollViewContentSize.width)
         .scrollIndicators(.hidden)
         .scrollBounceBehavior(.basedOnSize)
+    }
+    
+    func geometryReaderBackground(geoSize: CGSize) -> some View {
+        Task { @MainActor in
+            scrollViewContentSize = geoSize
+        }
+        return Color.clear
     }
     
     @ViewBuilder


### PR DESCRIPTION
Closes #10. Added a `.truncate` method to `[BlockNode]`:

```swift
let markdown = [BlockNode](markdown: string).truncate(lineCount: 5, charactersPerLine: 40)
```

This truncates the tree to *roughly* the given line count. This will be useful in `LargePost`. 

In cases where we need the *rendered* markdown to fit an exact size (such as in the tiled posts), this won't work. In those cases, we'll need an alternative solution. It would be possible to choose whether to render based on size, but it could be tricky to implement and may involve not supporting certain markdown elements. I haven't looked into it yet.