### PR TITLE
Rendering markdown in a single `Text` view

### DIFF
--- a/Sources/LemmyMarkdownUI/MarkdownConfiguration.swift
+++ b/Sources/LemmyMarkdownUI/MarkdownConfiguration.swift
@@ -35,7 +35,7 @@ public struct MarkdownConfiguration {
         spoilerOutlineColor: Color = Color(uiColor: .tertiaryLabel),
         codeBackgroundColor: Color = .init(uiColor: .secondarySystemBackground),
         quoteBarColor: Color = .init(uiColor: .tertiaryLabel),
-        quoteColor: Color = .primary
+        quoteColor: Color = .secondary
     ) {
         self.inlineImageLoader = inlineImageLoader
         self.imageBlockView = imageBlockView

--- a/Sources/LemmyMarkdownUI/Node/BlockNode.swift
+++ b/Sources/LemmyMarkdownUI/Node/BlockNode.swift
@@ -15,7 +15,7 @@ public enum BlockNode: Hashable, Node {
     case numberedList(isTight: Bool, start: Int, items: [ListItemNode], truncatedRows: Int = 0)
     case codeBlock(fenceInfo: String?, content: String, truncatedRows: Int = 0)
     case paragraph(inlines: [InlineNode])
-    case heading(level: Int, inlines: [InlineNode])
+    case heading(level: HeadingLevel, inlines: [InlineNode])
     case table(columnAlignments: [RawTableColumnAlignment], rows: [TableRowNode], truncatedRows: Int = 0)
     case thematicBreak
     
@@ -166,7 +166,7 @@ internal extension BlockNode {
             self = .paragraph(inlines: unsafeNode.children.compactMap(InlineNode.init(unsafeNode:)))
         case .heading:
             self = .heading(
-                level: unsafeNode.headingLevel,
+                level: .init(rawValue: unsafeNode.headingLevel) ?? ._6,
                 inlines: unsafeNode.children.compactMap(InlineNode.init(unsafeNode:))
             )
             case .table:

--- a/Sources/LemmyMarkdownUI/Node/[BlockNode].swift
+++ b/Sources/LemmyMarkdownUI/Node/[BlockNode].swift
@@ -16,6 +16,18 @@ public extension [BlockNode] {
         self.reduce([], { $0 + $1.links })
     }
     
+    var isSimpleParagraphs: Bool {
+        for node in self {
+            switch node {
+            case let .paragraph(inlines: inlines):
+                if inlines.isSingleImage { return false }
+            default:
+                return false
+            }
+        }
+        return true
+    }
+    
     internal func truncate(data: TruncationData) -> [BlockNode] {
         var ret: [BlockNode] = .init()
         for node in self {

--- a/Sources/LemmyMarkdownUI/Node/[InlineNode].swift
+++ b/Sources/LemmyMarkdownUI/Node/[InlineNode].swift
@@ -21,6 +21,21 @@ public extension [InlineNode] {
         self.reduce("", { $0 + $1.stringLiteral })
     }
     
+    var isSingleImage: Bool {
+        var canBeSingleImage = false
+        for node in self {
+            switch node {
+            case .image:
+                canBeSingleImage = true
+            default:
+                if !node.stringLiteral.allSatisfy(\.isWhitespace) {
+                    return false
+                }
+            }
+        }
+        return canBeSingleImage
+    }
+    
     internal func truncate(data: TruncationData) -> [InlineNode] {
         var charactersEaten: Int = 0
         data.linesRemaining -= 1

--- a/Sources/LemmyMarkdownUI/Renderer/InlineRenderer.swift
+++ b/Sources/LemmyMarkdownUI/Renderer/InlineRenderer.swift
@@ -21,6 +21,19 @@ internal class InlineRenderer {
     enum Component {
         case text(AttributedString)
         case image(InlineImage)
+        
+        static func newLine(_ count: Int = 1) -> Self {
+            .text(.init(.init(repeating: "\n", count: count)))
+        }
+        
+        var isNewLine: Bool {
+            switch self {
+            case .text(let attributedString):
+                !attributedString.characters.isEmpty && attributedString.characters.allSatisfy(\.isNewline)
+            case .image:
+                false
+            }
+        }
     }
     
     var type: InlineType!
@@ -32,6 +45,15 @@ internal class InlineRenderer {
     init(inlines: [InlineNode], configuration: MarkdownConfiguration) {
         renderInlines(inlines: inlines, configuration: configuration)
         components.append(.text(currentText))
+        chooseType()
+    }
+    
+    init(blocks: [BlockNode], configuration: MarkdownConfiguration) {
+        renderBlocks(blocks: blocks, configuration: configuration, withNewlines: true)
+        chooseType()
+    }
+    
+    private func chooseType() {
         if images.count == 1, let image = images.first {
             var isSingleImage = true
             loop: for component in components {
@@ -53,10 +75,95 @@ internal class InlineRenderer {
         self.type = .text(components: components, images: images)
     }
     
+    private func renderBlocks(
+        blocks: [BlockNode],
+        attributes: AttributeContainer = .init(),
+        configuration: MarkdownConfiguration,
+        withNewlines: Bool = false
+    ) {
+        for (index, block) in blocks.enumerated() {
+            if withNewlines || (index != 0 && index != blocks.count - 1) {
+                components.newline(2)
+            }
+            switch block {
+            case let .paragraph(inlines):
+                renderInlines(
+                    inlines: inlines,
+                    attributes: attributes,
+                    configuration: configuration
+                )
+            case let .heading(level: level, inlines: inlines):
+                var attributes = attributes
+                attributes.font = level.font
+                renderInlines(
+                    inlines: inlines,
+                    attributes: attributes,
+                    configuration: configuration
+                )
+            case let .blockquote(blocks: blocks):
+                var attributes = attributes
+                attributes.foregroundColor = configuration.quoteColor
+                renderBlocks(
+                    blocks: blocks,
+                    attributes: attributes,
+                    configuration: configuration
+                )
+            case let .spoiler(title: title, blocks: _):
+                var attributes = attributes
+                attributes.foregroundColor = configuration.secondaryColor
+                components.append(.text(.init("[Spoiler] \(title ?? "")", attributes: attributes)))
+            case .table:
+                var attributes = attributes
+                attributes.foregroundColor = configuration.secondaryColor
+                components.append(.text(.init("[Table]", attributes: attributes)))
+            case let .codeBlock(fenceInfo: _, content: content, truncatedRows: _):
+                var attributes = attributes
+                attributes.font = .body.monospaced()
+                attributes.foregroundColor = configuration.secondaryColor
+                components.append(.text(.init(content, attributes: attributes)))
+            case let .bulletedList(isTight: _, items: items, truncatedRows: _):
+                var bulletAttributes = attributes
+                bulletAttributes.foregroundColor = configuration.secondaryColor
+                for (index, item) in items.enumerated() {
+                    components.append(.text(.init("- ", attributes: bulletAttributes)))
+                    renderBlocks(
+                        blocks: item.blocks,
+                        attributes: attributes,
+                        configuration: configuration
+                    )
+                    components.newline(index == items.count - 1 ? 2 : 1)
+                }
+            case let .numberedList(isTight: _, start: start, items: items, truncatedRows: _):
+                var bulletAttributes = attributes
+                bulletAttributes.foregroundColor = configuration.secondaryColor
+                for (index, item) in items.enumerated() {
+                    components.append(.text(.init("\(start + index). ", attributes: bulletAttributes)))
+                    renderBlocks(
+                        blocks: item.blocks,
+                        attributes: attributes,
+                        configuration: configuration
+                    )
+                    components.newline(index == items.count - 1 ? 2 : 1)
+                }
+            default:
+                break
+            }
+            if withNewlines || (index != 0 && index != blocks.count - 1) {
+                components.newline(2)
+            }
+        }
+        if let last = components.last, last.isNewLine {
+            components.removeLast()
+        }
+        
+        print(components)
+    }
+    
     private func renderInlines(
         inlines: [InlineNode],
         attributes: AttributeContainer = .init(),
-        configuration: MarkdownConfiguration
+        configuration: MarkdownConfiguration,
+        isRoot: Bool = true
     ) {
         for node in inlines {
             if let string = node.string {
@@ -83,10 +190,40 @@ internal class InlineRenderer {
                     renderInlines(
                         inlines: node.inlineChildren,
                         attributes: node.applyAttributes(attributes, configuration: configuration),
-                        configuration: configuration
+                        configuration: configuration,
+                        isRoot: false
                     )
                 }
             }
+        }
+        if isRoot {
+            components.append(.text(currentText))
+            currentText = .init()
+        }
+    }
+}
+
+extension [InlineRenderer.Component] {
+    func text(configuration: MarkdownConfiguration) -> Text {
+        var text = Text("")
+        for component in self {
+            switch component {
+            case let .text(attributedString):
+                // swiftlint:disable:next shorthand_operator
+                text = text + Text(attributedString)
+            case let .image(attatchment):
+
+                let image: Image = attatchment.image ?? Image(systemName: "arrow.down.circle")
+                // swiftlint:disable:next shorthand_operator
+                text = text + Text(image)
+            }
+        }
+        return text
+    }
+    
+    mutating func newline(_ count: Int = 1) {
+        if let last, !last.isNewLine {
+            append(.newLine(count))
         }
     }
 }

--- a/Sources/LemmyMarkdownUI/Unsafe/HeadingLevel.swift
+++ b/Sources/LemmyMarkdownUI/Unsafe/HeadingLevel.swift
@@ -1,0 +1,30 @@
+//
+//  File.swift
+//  
+//
+//  Created by Sjmarf on 01/06/2024.
+//
+
+import SwiftUI
+
+public enum HeadingLevel: Int {
+    case _1 = 1
+    case _2 = 2
+    case _3 = 3
+    case _4 = 4
+    case _5 = 5
+    case _6 = 6
+    
+    internal var font: Font {
+        switch self {
+        case ._1:
+            .title.weight(.bold)
+        case ._2:
+            .title2.weight(.bold)
+        case ._3:
+            .title3.weight(.semibold)
+        default:
+            .headline.weight(.semibold)
+        }
+    }
+}

--- a/Sources/LemmyMarkdownUI/View/Markdown.swift
+++ b/Sources/LemmyMarkdownUI/View/Markdown.swift
@@ -95,37 +95,21 @@ public struct Markdown: View {
     
     @ViewBuilder
     func inlineMarkdown(_ inlines: [InlineNode]) -> some View {
-        InlineMarkdown(
+        MarkdownText(
             inlines,
             configuration: configuration
         )
     }
     
     @ViewBuilder
-    func heading(level: Int, inlines: [InlineNode]) -> some View {
-        Group {
-            switch level {
-            case 1:
-                VStack(alignment: .leading, spacing: 0) {
-                    inlineMarkdown(inlines)
-                        .font(.title)
-                        .fontWeight(.bold)
+    func heading(level: HeadingLevel, inlines: [InlineNode]) -> some View {
+            VStack(alignment: .leading, spacing: 0) {
+                inlineMarkdown(inlines)
+                    .font(level.font)
+                if level == ._1 {
                     Divider()
                 }
-            case 2:
-                inlineMarkdown(inlines)
-                    .font(.title2)
-                    .fontWeight(.bold)
-            case 3:
-                inlineMarkdown(inlines)
-                    .font(.title3)
-                    .fontWeight(.semibold)
-            default:
-                inlineMarkdown(inlines)
-                    .font(.headline)
-                    .fontWeight(.semibold)
             }
-        }
     }
     
     @ViewBuilder


### PR DESCRIPTION
Renamed `InlineMarkdown` to `MarkdownText`, and added capability for rendering a `[BlockNode]` tree. This allows us to easily render markdown with a set `.lineLimit`, or otherwise constrain it to some size. Obviously, this comes with some caveats - it won't render tables or spoiler content, for example, and code blocks don't scroll horizontally.