### PR TITLE
Fix emoji rendering

### DIFF
--- a/Sources/LemmyMarkdownUI/Renderer/InlineRenderer.swift
+++ b/Sources/LemmyMarkdownUI/Renderer/InlineRenderer.swift
@@ -248,19 +248,13 @@ extension [InlineRenderer.Component] {
         for component in self {
             switch component {
             case let .image(image):
-                let presentationMode: FinalImagePresentationMode = switch configuration.imagePresentationMode {
-                case .contextual: image.renderFullWidth ? .block : .inline
-                case .block: .block
-                case .inline : .inline
-                }
-                switch presentationMode {
-                case .block:
+                if image.renderFullWidth(in: configuration) {
                     if !current.isEmpty {
                         output.append(current)
                     }
                     output.append([component])
                     current = []
-                case .inline:
+                } else {
                     current.append(component)
                 }
             case .text:
@@ -272,8 +266,4 @@ extension [InlineRenderer.Component] {
         }
         return output
     }
-}
-
-private enum FinalImagePresentationMode {
-    case block, inline
 }

--- a/Sources/LemmyMarkdownUI/Renderer/MarkdownImage.swift
+++ b/Sources/LemmyMarkdownUI/Renderer/MarkdownImage.swift
@@ -17,12 +17,16 @@ public class MarkdownImage {
     public var image: Image?
     public var parentLink: URL?
     
-    public var renderFullWidth: Bool {
+    public func renderFullWidth(in configuration: MarkdownConfiguration) -> Bool {
         // Only custom emojis should be displayed inline. Custom emojis have tooltips.
         // People are unlikely to use tooltips in any other circumstances, so images
         // with tooltips are displayed inline. I haven't found a better way to test for
         // a custom emoji.
-        tooltip == nil
+        switch configuration.imagePresentationMode {
+        case .block: true
+        case .inline: false
+        case .contextual: tooltip == nil
+        }
     }
     
     init(

--- a/Sources/LemmyMarkdownUI/View/MarkdownText.swift
+++ b/Sources/LemmyMarkdownUI/View/MarkdownText.swift
@@ -50,7 +50,7 @@ public struct MarkdownText: View {
             VStack(alignment: .leading, spacing: 8) {
                 ForEach(Array(groupedComponents.enumerated()), id: \.offset) { _, group in
                     if group.count == 1, let item = group.first {
-                        if case let .image(image) = item {
+                        if case let .image(image) = item, image.renderFullWidth(in: configuration) {
                             configuration.imageBlockView(image)
                         } else {
                             group.text(configuration: configuration)


### PR DESCRIPTION
Emojis were rendered as full images if the message contained only the emoji and nothing else