### PR TITLE
Add syntax highlighting for code blocks

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "highlightswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/appstefan/highlightswift.git",
+      "state" : {
+        "revision" : "784ca3ccfc8a2cf724fbb2f06cb6ec3329424da3",
+        "version" : "1.1.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,19 @@ let package = Package(
             name: "LemmyMarkdownUI",
             targets: ["LemmyMarkdownUI"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/appstefan/highlightswift.git", from: "1.1.0")
+    ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(name: "cmark-lemmy"),
         .target(
-            name: "LemmyMarkdownUI", dependencies: ["cmark-lemmy"]),
+            name: "LemmyMarkdownUI",
+            dependencies: [
+                "cmark-lemmy",
+                .product(name: "HighlightSwift", package: "highlightswift")
+            ]),
         .testTarget(
             name: "LemmyMarkdownUITests",
             dependencies: ["LemmyMarkdownUI"]),

--- a/Sources/LemmyMarkdownUI/MarkdownConfiguration.swift
+++ b/Sources/LemmyMarkdownUI/MarkdownConfiguration.swift
@@ -29,6 +29,8 @@ public struct MarkdownConfiguration {
     public var unloadedImageIcon: String
     public var font: UIFont
     public var codeFontScaleFactor: Double
+
+    public var enableSyntaxHighlighting: Bool
     
     public init(
         imagePresentationMode: ImagePresentationMode = .contextual,
@@ -48,7 +50,8 @@ public struct MarkdownConfiguration {
         quoteBarColor: Color = .init(uiColor: .tertiaryLabel),
         quoteColor: Color = .secondary,
         font: UIFont.TextStyle = .body,
-        codeFontScaleFactor: Double = 1
+        codeFontScaleFactor: Double = 1,
+        enableSyntaxHighlighting: Bool = true
     ) {
         self.imagePresentationMode = imagePresentationMode
         
@@ -73,6 +76,8 @@ public struct MarkdownConfiguration {
         
         self.font = .preferredFont(forTextStyle: font)
         self.codeFontScaleFactor = codeFontScaleFactor
+
+        self.enableSyntaxHighlighting = enableSyntaxHighlighting
     }
     
     internal func withFont(_ font: UIFont) -> Self {

--- a/Sources/LemmyMarkdownUI/View/CodeBlockView.swift
+++ b/Sources/LemmyMarkdownUI/View/CodeBlockView.swift
@@ -89,7 +89,9 @@ internal struct CodeBlockView: View {
             } catch {
                 print("Syntax highlighting failed: \(error)")
             }
-            isHighlighting = false
+            await MainActor.run {
+                isHighlighting = false
+            }
         }
     }
 }

--- a/Sources/LemmyMarkdownUI/View/CodeBlockView.swift
+++ b/Sources/LemmyMarkdownUI/View/CodeBlockView.swift
@@ -70,7 +70,7 @@ internal struct CodeBlockView: View {
         guard !isHighlighting else { return }
 
         isHighlighting = true
-        highlightTask = Task {
+        highlightTask = Task.detached {
             do {
                 let highlight = Highlight()
                 let colors: HighlightColors = colorScheme == .dark ? .dark(.github) : .light(.github)

--- a/Sources/LemmyMarkdownUI/View/CodeBlockView.swift
+++ b/Sources/LemmyMarkdownUI/View/CodeBlockView.swift
@@ -6,11 +6,25 @@
 //
 
 import SwiftUI
+import HighlightSwift
 
 internal struct CodeBlockView: View {
     let content: String
+    let language: String?
     let configuration: MarkdownConfiguration
-    
+
+    @State private var highlightedText: AttributedString?
+    @State private var isHighlighting = false
+    @State private var highlightTask: Task<Void, Never>?
+
+    @Environment(\.colorScheme) var colorScheme
+
+    init(content: String, language: String? = nil, configuration: MarkdownConfiguration) {
+        self.content = content
+        self.language = language
+        self.configuration = configuration
+    }
+
     var body: some View {
         Group {
             if configuration.wrapCodeBlockLines {
@@ -22,15 +36,60 @@ internal struct CodeBlockView: View {
         }
         .background(configuration.codeBackgroundColor)
         .clipShape(RoundedRectangle(cornerRadius: 8))
+        .task(id: colorScheme) {
+            await performHighlighting()
+        }
+        .onDisappear {
+            highlightTask?.cancel()
+        }
     }
-    
+
+    @ViewBuilder
     var contentView: some View {
-        Text(content.trimmingCharacters(in: .newlines))
-            .font(
-                Font(
-                    configuration.font.withSize(configuration.font.pointSize * configuration.codeFontScaleFactor)
-                ).monospaced()
-            )
-            .padding(10)
+        if let highlighted = highlightedText,
+           configuration.enableSyntaxHighlighting {
+            Text(highlighted)
+                .font(codeFont)
+                .padding(10)
+        } else {
+            Text(content.trimmingCharacters(in: .newlines))
+                .font(codeFont)
+                .foregroundColor(configuration.primaryColor)
+                .padding(10)
+        }
+    }
+
+    var codeFont: Font {
+        Font(
+            configuration.font.withSize(configuration.font.pointSize * configuration.codeFontScaleFactor)
+        ).monospaced()
+    }
+
+    func performHighlighting() async {
+        guard configuration.enableSyntaxHighlighting else { return }
+        guard !isHighlighting else { return }
+
+        isHighlighting = true
+        highlightTask = Task {
+            do {
+                let highlight = Highlight()
+                let colors: HighlightColors = colorScheme == .dark ? .dark(.github) : .light(.github)
+
+                if let lang = language, !lang.isEmpty {
+                    let highlighted = try await highlight.attributedText(content, language: lang, colors: colors)
+                    await MainActor.run {
+                        self.highlightedText = highlighted
+                    }
+                } else {
+                    let highlighted = try await highlight.attributedText(content, colors: colors)
+                    await MainActor.run {
+                        self.highlightedText = highlighted
+                    }
+                }
+            } catch {
+                print("Syntax highlighting failed: \(error)")
+            }
+            isHighlighting = false
+        }
     }
 }

--- a/Sources/LemmyMarkdownUI/View/Markdown.swift
+++ b/Sources/LemmyMarkdownUI/View/Markdown.swift
@@ -53,9 +53,10 @@ public struct Markdown: View {
                         )
                         .markdownMinimumSpacing(16)
                     case let .codeBlock(fenceInfo: fenceInfo, content: content):
+                        let language = fenceInfo?.split(separator: " ").first.map(String.init)
                         CodeBlockView(
                             content: content,
-                            language: fenceInfo?.split(separator: " ").first.map(String.init),
+                            language: language?.isEmpty == true ? nil : language,
                             configuration: configuration
                         )
                             .markdownMinimumSpacing(16)

--- a/Sources/LemmyMarkdownUI/View/Markdown.swift
+++ b/Sources/LemmyMarkdownUI/View/Markdown.swift
@@ -52,8 +52,12 @@ public struct Markdown: View {
                             configuration: configuration
                         )
                         .markdownMinimumSpacing(16)
-                    case let .codeBlock(fenceInfo: _, content: content):
-                        CodeBlockView(content: content, configuration: configuration)
+                    case let .codeBlock(fenceInfo: fenceInfo, content: content):
+                        CodeBlockView(
+                            content: content,
+                            language: fenceInfo?.split(separator: " ").first.map(String.init),
+                            configuration: configuration
+                        )
                             .markdownMinimumSpacing(16)
                     case .thematicBreak:
                         Rectangle()


### PR DESCRIPTION
- Added `HighlightSwift` as a package dependency and updated the `LemmyMarkdownUI` target to depend on it.
- Updated `CodeBlockView` to perform asynchronous syntax highlighting using `HighlightSwift`, with support for light and dark color schemes, and proper cancellation of highlight tasks.
- Added a new `enableSyntaxHighlighting` property to `MarkdownConfiguration` to allow toggling syntax highlighting, with a default value of `true`.